### PR TITLE
Update Airship SDK to 18.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First create a file with all your Urban Airship setting ([example](./demo/app/ur
     ```ts
     public onCreate(): void {
         super.onCreate();
-    
+
         NsUrbanAirship.getInstance().startUp(urbanAirshipSettings, this);
     }
     ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NativeScript plugin for Urban Airship
 [![npm version](https://badge.fury.io/js/nativescript-urban-airship.svg)](https://www.npmjs.com/package/nativescript-urban-airship)
 
-This is a plugin to use the [Urban Airship](https://www.urbanairship.com/) SDK (Android v15.0.0, iOS v15.0.1) with NativeScript.  
+This is a plugin to use the [Urban Airship](https://www.urbanairship.com/) SDK (Android v18.7.1, iOS v18.7.1) with NativeScript.
 For iOS this plugin uses APNS and for Android it uses FCM.
 
 ## Requirements

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -6,7 +6,7 @@ repositories {
     jcenter()
 }
 dependencies {
-    def airshipVersion = "16.7.0"
+    def airshipVersion = "18.7.1"
     implementation "com.urbanairship.android:urbanairship-automation:$airshipVersion"
 
     implementation "com.urbanairship.android:urbanairship-fcm:$airshipVersion"

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,4 +1,4 @@
 platform :ios, '13.0'
 
-pod 'Airship' , '~> 16.9.0'
+pod 'Airship' , '~> 18.7'
 pod 'Airship/PreferenceCenter'

--- a/src/urban-airship.android.ts
+++ b/src/urban-airship.android.ts
@@ -13,7 +13,7 @@ export class NsUrbanAirship implements CommonUrbanAirship {
         }
         NsUrbanAirship.instance = this;
     }
- 
+
     static getInstance() {
         return NsUrbanAirship.instance;
     }

--- a/src/urban-airship.ios.ts
+++ b/src/urban-airship.ios.ts
@@ -26,7 +26,7 @@ export class NsUrbanAirship implements CommonUrbanAirship {
         config.URLAllowList = NSArray.arrayWithArray([urbanAirshipSettings.urlAllowList]);
         config.URLAllowListScopeJavaScriptInterface = NSArray.arrayWithArray([urbanAirshipSettings.urlAllowListScopeJavaScriptInterface]);
         config.URLAllowListScopeOpenURL = NSArray.arrayWithArray([urbanAirshipSettings.urlAllowListScopeOpenURL]);
-        
+
         UAirship.takeOffLaunchOptions(config, null);
         if (!this.pushIsValid()) {
             return;
@@ -65,7 +65,7 @@ export class NsUrbanAirship implements CommonUrbanAirship {
             resolve(this.isOptIn());
         });
     }
-    
+
     public isOptIn(): boolean {
         if (!this.pushIsValid()) {
             return false;


### PR DESCRIPTION
## Summary
- bump Android Airship SDK version to 18.7.1
- bump iOS Airship pod to ~> 18.7
- document new SDK version in README
- remove trailing whitespace caught by lint

## Testing
- `npm --prefix src run ci.tslint`

------
https://chatgpt.com/codex/tasks/task_e_687a6953e210832faeb5d0ccc8a480ab